### PR TITLE
fix: return piece accept receipt error

### DIFF
--- a/packages/filecoin-api/src/storefront/service.js
+++ b/packages/filecoin-api/src/storefront/service.js
@@ -288,14 +288,19 @@ export const filecoinInfo = async ({ capability }, context) => {
     return processingResult
   }
 
-  const pieceAcceptOut = /** @type {API.FilecoinAcceptSuccess} */ (
-    pieceAcceptReceiptGet.ok?.out.ok
-  )
+  const pieceAcceptOut =
+    /** @type {API.Result<API.FilecoinAcceptSuccess, API.FilecoinAcceptFailure>} */
+    (pieceAcceptReceiptGet.ok.out)
+
+  // If piece accept receipt was in error, return the error so user can remedy.
+  if (pieceAcceptOut.error) {
+    return pieceAcceptOut
+  }
 
   // Query current info of aggregate from deal tracker
   const info = await DealTracker.dealInfo(
     context.dealTrackerService.invocationConfig,
-    pieceAcceptOut.aggregate,
+    pieceAcceptOut.ok.aggregate,
     { connection: context.dealTrackerService.connection }
   )
 
@@ -308,12 +313,12 @@ export const filecoinInfo = async ({ capability }, context) => {
     piece,
     aggregates: [
       {
-        aggregate: pieceAcceptOut.aggregate,
-        inclusion: pieceAcceptOut.inclusion,
+        aggregate: pieceAcceptOut.ok.aggregate,
+        inclusion: pieceAcceptOut.ok.inclusion,
       },
     ],
     deals: deals.map(([dealId, dealDetails]) => ({
-      aggregate: pieceAcceptOut.aggregate,
+      aggregate: pieceAcceptOut.ok.aggregate,
       provider: dealDetails.provider,
       aux: {
         dataType: 0n,


### PR DESCRIPTION
This was causing the following error in production:

```
2024-06-21T04:05:01.605Z	ee3a792e-71d8-4188-9a45-a3f44a153719	WARN	HandlerExecutionError: service handler {can: "filecoin/info"} error: Cannot read properties of undefined (reading 'aggregate')
    at invoke (/node_modules/@ucanto/server/src/server.js:157:21)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at run (/node_modules/@web3-storage/upload-api/src/lib.js:169:10)
    ... 4 lines matching cause stack trace ...
    at processResult (/node_modules/src/awslambda.ts:326:50) {
  capability: {
    nb: {
      piece: CID(bafkzcibdyuhqqhgb72e23rtoielekn2lsknb4naxhvyz6fhsd7bms4ld6ghbaiqi)
    },
    can: 'filecoin/info',
    with: 'did:key:z6MkiBeiHFA6kbA2mchg1F9juxCuHuLgymzJpanKswpBZmQT'
  },
  cause: TypeError: Cannot read properties of undefined (reading 'aggregate')
      at filecoinInfo (/node_modules/@web3-storage/filecoin-api/src/storefront/service.js:298:20)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at invoke (/node_modules/@ucanto/server/src/server.js:145:23)
      at run (/node_modules/@web3-storage/upload-api/src/lib.js:169:10)
      at async Promise.all (index 0)
      at execute (/node_modules/@web3-storage/upload-api/src/lib.js:139:5)
      at handle (/node_modules/@web3-storage/upload-api/src/lib.js:108:20)
      at ucanInvocationRouter (/upload-api/functions/ucan-invocation-router.js:298:20)
      at processResult (/node_modules/src/awslambda.ts:326:50),
  error: true
}
```