### PR TITLE
feat(filecoin-api): paginated queries

### DIFF
--- a/packages/filecoin-api/package.json
+++ b/packages/filecoin-api/package.json
@@ -149,7 +149,8 @@
     "check": "tsc --build",
     "lint": "tsc --build && eslint '**/*.{js,ts}'",
     "test": "mocha --bail --timeout 10s -n no-warnings -n experimental-vm-modules -n experimental-fetch test/**/*.spec.js",
-    "test-watch": "pnpm build && mocha --bail --timeout 10s --watch --parallel -n no-warnings -n experimental-vm-modules -n experimental-fetch --watch-files src,test"
+    "test-watch": "pnpm build && mocha --bail --timeout 10s --watch --parallel -n no-warnings -n experimental-vm-modules -n experimental-fetch --watch-files src,test",
+    "coverage": "c8 -r text -r html npm run test"
   },
   "dependencies": {
     "@ipld/dag-ucan": "^3.4.0",
@@ -172,6 +173,7 @@
     "@web-std/blob": "^3.0.5",
     "@web3-storage/eslint-config-w3up": "workspace:^",
     "@web3-storage/filecoin-client": "workspace:^",
+    "c8": "^10.1.2",
     "mocha": "^10.2.0",
     "multiformats": "^12.1.2",
     "one-webcrypto": "git://github.com/web3-storage/one-webcrypto",

--- a/packages/filecoin-api/src/aggregator/api.ts
+++ b/packages/filecoin-api/src/aggregator/api.ts
@@ -13,17 +13,15 @@ import {
   ServiceConfig,
 } from '../types.js'
 
-export type PieceStore = UpdatableStore<PieceRecordKey, PieceRecord>
+export type PieceStore = Store<PieceRecordKey, PieceRecord> &
+  UpdatableStore<PieceRecordKey, PieceRecord>
 export type PieceQueue = Queue<PieceMessage>
 export type BufferQueue = Queue<BufferMessage>
 export type BufferStore = Store<Link, BufferRecord>
 export type AggregateStore = Store<AggregateRecordKey, AggregateRecord>
 export type PieceAcceptQueue = Queue<PieceAcceptMessage>
-export type InclusionStore = QueryableStore<
-  InclusionRecordKey,
-  InclusionRecord,
-  InclusionRecordQueryByGroup
->
+export type InclusionStore = Store<InclusionRecordKey, InclusionRecord> &
+  QueryableStore<InclusionRecordQueryByGroup, InclusionRecord>
 export type AggregateOfferQueue = Queue<AggregateOfferMessage>
 
 export interface ServiceContext {

--- a/packages/filecoin-api/src/aggregator/service.js
+++ b/packages/filecoin-api/src/aggregator/service.js
@@ -82,7 +82,7 @@ export const pieceAccept = async ({ capability }, context) => {
       error: new StoreOperationFailed(getInclusionRes.error?.message),
     }
   }
-  if (!getInclusionRes.ok.length) {
+  if (!getInclusionRes.ok.results.length) {
     return {
       error: new UnexpectedState(
         `no inclusion proof found for pair {${piece}, ${group}}`
@@ -91,7 +91,7 @@ export const pieceAccept = async ({ capability }, context) => {
   }
 
   // Get buffered pieces
-  const [{ aggregate, inclusion }] = getInclusionRes.ok
+  const [{ aggregate, inclusion }] = getInclusionRes.ok.results
   const getAggregateRes = await context.aggregateStore.get({ aggregate })
   if (getAggregateRes.error) {
     return {

--- a/packages/filecoin-api/src/deal-tracker/api.ts
+++ b/packages/filecoin-api/src/deal-tracker/api.ts
@@ -1,12 +1,9 @@
 import type { Signer } from '@ucanto/interface'
 import { PieceLink } from '@web3-storage/data-segment'
-import { QueryableStore } from '../types.js'
+import { Store, QueryableStore } from '../types.js'
 
-export type DealStore = QueryableStore<
-  DealRecordKey,
-  DealRecord,
-  DealRecordQueryByPiece
->
+export type DealStore = Store<DealRecordKey, DealRecord> &
+  QueryableStore<DealRecordQueryByPiece, DealRecord>
 
 export interface ServiceContext {
   /**

--- a/packages/filecoin-api/src/deal-tracker/service.js
+++ b/packages/filecoin-api/src/deal-tracker/service.js
@@ -22,7 +22,7 @@ export const dealInfo = async ({ capability }, context) => {
   const records = []
   /** @type {string|undefined} */
   let cursor
-  while (true) {
+  do {
     const storeQuery = await context.dealStore.query({ piece }, { cursor })
     if (storeQuery.error) {
       return { error: new StoreOperationFailed(storeQuery.error.message) }
@@ -30,8 +30,7 @@ export const dealInfo = async ({ capability }, context) => {
 
     records.push(...storeQuery.ok.results)
     cursor = storeQuery.ok.cursor
-    if (!cursor) break
-  }
+  } while (cursor)
 
   return {
     ok: {

--- a/packages/filecoin-api/src/dealer/api.ts
+++ b/packages/filecoin-api/src/dealer/api.ts
@@ -5,17 +5,17 @@ import {
   DealTrackerService,
 } from '@web3-storage/filecoin-client/types'
 import {
+  Store,
   UpdatableStore,
-  UpdatableAndQueryableStore,
+  QueryableStore,
   ServiceConfig,
 } from '../types.js'
 
-export type OfferStore<OfferDoc> = UpdatableStore<string, OfferDoc>
-export type AggregateStore = UpdatableAndQueryableStore<
-  AggregateRecordKey,
-  AggregateRecord,
-  Pick<AggregateRecord, 'status'>
->
+export type OfferStore<OfferDoc> = Store<string, OfferDoc> &
+  UpdatableStore<string, OfferDoc>
+export type AggregateStore = Store<AggregateRecordKey, AggregateRecord> &
+  UpdatableStore<AggregateRecordKey, AggregateRecord> &
+  QueryableStore<Pick<AggregateRecord, 'status'>, AggregateRecord>
 
 export interface ServiceContext<OfferDoc = OfferDocument> {
   id: Signer

--- a/packages/filecoin-api/src/dealer/events.js
+++ b/packages/filecoin-api/src/dealer/events.js
@@ -7,6 +7,9 @@ import { StoreOperationFailed } from '../errors.js'
  * @typedef {import('./api.js').AggregateRecordKey} AggregateRecordKey
  */
 
+/** Max items per page of query. */
+const MAX_PAGE_SIZE = 20
+
 /**
  * On aggregate insert event, update offer key with date to be retrievable by broker.
  *
@@ -55,45 +58,58 @@ export const handleAggregateUpdatedStatus = async (context, record) => {
  * @param {import('./api.js').CronContext} context
  */
 export const handleCronTick = async (context) => {
-  // Get offered deals pending approval/rejection
-  const offeredDeals = await context.aggregateStore.query({
-    status: 'offered',
-  })
-  if (offeredDeals.error) {
-    return {
-      error: offeredDeals.error,
-    }
-  }
-
-  // Update approved deals from the ones resolved
-  const updatedResponses = await Promise.all(
-    offeredDeals.ok.map((deal) =>
-      updateApprovedDeals({
-        deal,
-        aggregateStore: context.aggregateStore,
-        dealTrackerServiceConnection: context.dealTrackerService.connection,
-        dealTrackerInvocationConfig:
-          context.dealTrackerService.invocationConfig,
-      })
+  let totalDealsCount = 0
+  let updatedDealsCount = 0
+  /** @type {string|undefined} */
+  let cursor
+  while (true) {
+    // Get offered deals pending approval/rejection
+    const offeredDeals = await context.aggregateStore.query(
+      {
+        status: 'offered',
+      },
+      { cursor, size: MAX_PAGE_SIZE }
     )
-  )
-
-  // Fail if one or more update operations did not succeed.
-  // The successful ones are still valid, but we should keep track of errors for monitoring/alerting.
-  const updateErrorResponse = updatedResponses.find((r) => r.error)
-  if (updateErrorResponse) {
-    return {
-      error: updateErrorResponse.error,
+    if (offeredDeals.error) {
+      return {
+        error: offeredDeals.error,
+      }
     }
+    totalDealsCount += offeredDeals.ok.results.length
+
+    // Update approved deals from the ones resolved
+    const updatedResponses = await Promise.all(
+      offeredDeals.ok.results.map((deal) =>
+        updateApprovedDeals({
+          deal,
+          aggregateStore: context.aggregateStore,
+          dealTrackerServiceConnection: context.dealTrackerService.connection,
+          dealTrackerInvocationConfig:
+            context.dealTrackerService.invocationConfig,
+        })
+      )
+    )
+
+    // Fail if one or more update operations did not succeed.
+    // The successful ones are still valid, but we should keep track of errors for monitoring/alerting.
+    const updateErrorResponse = updatedResponses.find((r) => r.error)
+    if (updateErrorResponse) {
+      return {
+        error: updateErrorResponse.error,
+      }
+    }
+
+    updatedDealsCount += updatedResponses.filter((r) => r.ok?.updated).length
+    cursor = offeredDeals.ok.cursor
+    if (!cursor) break
   }
 
   // Return successful update operation
   // Include in response the ones that were Updated, and the ones still pending response.
-  const updatedDealsCount = updatedResponses.filter((r) => r.ok?.updated).length
   return {
     ok: {
       updatedCount: updatedDealsCount,
-      pendingCount: updatedResponses.length - updatedDealsCount,
+      pendingCount: totalDealsCount - updatedDealsCount,
     },
   }
 }
@@ -103,7 +119,7 @@ export const handleCronTick = async (context) => {
  *
  * @param {object} context
  * @param {AggregateRecord} context.deal
- * @param {import('../types.js').UpdatableAndQueryableStore<AggregateRecordKey, AggregateRecord, Pick<AggregateRecord, 'status'>>} context.aggregateStore
+ * @param {import('../types.js').UpdatableStore<AggregateRecordKey, AggregateRecord>} context.aggregateStore
  * @param {import('@ucanto/interface').ConnectionView<any>} context.dealTrackerServiceConnection
  * @param {import('@web3-storage/filecoin-client/types').InvocationConfig} context.dealTrackerInvocationConfig
  */

--- a/packages/filecoin-api/src/dealer/events.js
+++ b/packages/filecoin-api/src/dealer/events.js
@@ -62,7 +62,7 @@ export const handleCronTick = async (context) => {
   let updatedDealsCount = 0
   /** @type {string|undefined} */
   let cursor
-  while (true) {
+  do {
     // Get offered deals pending approval/rejection
     const offeredDeals = await context.aggregateStore.query(
       {
@@ -101,8 +101,7 @@ export const handleCronTick = async (context) => {
 
     updatedDealsCount += updatedResponses.filter((r) => r.ok?.updated).length
     cursor = offeredDeals.ok.cursor
-    if (!cursor) break
-  }
+  } while (cursor)
 
   // Return successful update operation
   // Include in response the ones that were Updated, and the ones still pending response.

--- a/packages/filecoin-api/src/storefront/api.ts
+++ b/packages/filecoin-api/src/storefront/api.ts
@@ -18,17 +18,16 @@ import {
 } from '@web3-storage/filecoin-client/types'
 import {
   Store,
-  UpdatableAndQueryableStore,
+  UpdatableStore,
+  QueryableStore,
   Queue,
   ServiceConfig,
   StoreGetError,
 } from '../types.js'
 
-export type PieceStore = UpdatableAndQueryableStore<
-  PieceRecordKey,
-  PieceRecord,
-  Pick<PieceRecord, 'status'>
->
+export type PieceStore = Store<PieceRecordKey, PieceRecord> &
+  UpdatableStore<PieceRecordKey, PieceRecord> &
+  QueryableStore<Pick<PieceRecord, 'status'>, PieceRecord>
 export type FilecoinSubmitQueue = Queue<FilecoinSubmitMessage>
 export type PieceOfferQueue = Queue<PieceOfferMessage>
 export type TaskStore = Store<UnknownLink, Invocation>

--- a/packages/filecoin-api/src/storefront/events.js
+++ b/packages/filecoin-api/src/storefront/events.js
@@ -191,7 +191,7 @@ export const handleCronTick = async (context) => {
   let updatedPiecesCount = 0
   /** @type {string|undefined} */
   let cursor
-  while (true) {
+  do {
     const submittedPieces = await context.pieceStore.query(
       {
         status: 'submitted',
@@ -230,8 +230,7 @@ export const handleCronTick = async (context) => {
 
     updatedPiecesCount += updatedResponses.filter((r) => r.ok?.updated).length
     cursor = submittedPieces.ok.cursor
-    if (!cursor) break
-  }
+  } while (cursor)
 
   // Return successful update operation
   // Include in response the ones that were Updated, and the ones still pending response.

--- a/packages/filecoin-api/src/types.ts
+++ b/packages/filecoin-api/src/types.ts
@@ -42,7 +42,7 @@ export interface Store<RecKey, Rec> {
   has: (key: RecKey) => Promise<Result<boolean, StoreGetError>>
 }
 
-export interface UpdatableStore<RecKey, Rec> extends Store<RecKey, Rec> {
+export interface UpdatableStore<RecKey, Rec> {
   /**
    * Updates a record from the store.
    */
@@ -63,16 +63,36 @@ export interface ReadableStreamStore<RecKey, Rec> {
   stream: (key: RecKey) => Promise<Result<ReadableStream<Rec>, StoreGetError>>
 }
 
-export interface QueryableStore<RecKey, Rec, Query> extends Store<RecKey, Rec> {
+export interface ListSuccess<R> {
   /**
-   * Queries for record matching a given criterium.
+   * Opaque string specifying where to start retrival of the next page of
+   * results.
    */
-  query: (search: Query) => Promise<Result<Rec[], StoreGetError>>
+  cursor?: string
+  results: R[]
 }
 
-export interface UpdatableAndQueryableStore<RecKey, Rec, Query>
-  extends UpdatableStore<RecKey, Rec>,
-    QueryableStore<RecKey, Rec, Query> {}
+export interface Pageable {
+  /**
+   * Opaque string specifying where to start retrival of the next page of
+   * results.
+   */
+  cursor?: string
+  /**
+   * Maximum number of items to return.
+   */
+  size?: number
+}
+
+export interface QueryableStore<Query, Rec> {
+  /**
+   * Queries for record matching a given criteria.
+   */
+  query: (
+    search: Query,
+    options?: Pageable
+  ) => Promise<Result<ListSuccess<Rec>, StoreGetError>>
+}
 
 export interface QueueMessageOptions {
   messageGroupId?: string

--- a/packages/filecoin-api/test/context/store.js
+++ b/packages/filecoin-api/test/context/store.js
@@ -4,23 +4,33 @@ import { StoreOperationFailed, RecordNotFound } from '../../src/errors.js'
 /**
  * @typedef {import('../../src/types.js').StorePutError} StorePutError
  * @typedef {import('../../src/types.js').StoreGetError} StoreGetError
+ * @typedef {import('../../src/types.js').Pageable} Pageable
+ */
+
+/**
+ * @template T
+ * @typedef {import('../../src/types.js').ListSuccess<T>} ListSuccess
  */
 
 /**
  * @template K
  * @template V
+ * @template Q
  * @implements {API.Store<K, V>}
+ * @implements {API.UpdatableStore<K, V>}
+ * @implements {API.QueryableStore<Q, V>}
  */
 export class Store {
   /**
-   * @param {import('./types.js').StoreOptions<K, V>} options
+   * @param {import('./types.js').StoreOptions<K, V> & Partial<import('./types.js').UpdatableStoreOptions<K, V>> & Partial<import('./types.js').QueryableStoreOptions<Q, V>> & Partial<import('./types.js').ReadableStreamStoreOptions<K, V>>} options
    */
   constructor(options) {
     /** @type {Set<V>} */
     this.items = new Set()
-
     this.getFn = options.getFn
+    this.updateFn = options.updateFn
     this.queryFn = options.queryFn
+    this.streamFn = options.streamFn
   }
 
   /**
@@ -41,9 +51,6 @@ export class Store {
    * @returns {Promise<import('@ucanto/interface').Result<V, StoreGetError>>}
    */
   async get(item) {
-    if (!this.getFn) {
-      throw new Error('get not supported')
-    }
     const t = this.getFn(this.items, item)
     if (!t) {
       return {
@@ -60,9 +67,6 @@ export class Store {
    * @returns {Promise<import('@ucanto/interface').Result<boolean, StoreGetError>>}
    */
   async has(item) {
-    if (!this.getFn) {
-      throw new Error('has not supported')
-    }
     const t = this.getFn(this.items, item)
     if (!t) {
       return {
@@ -75,14 +79,30 @@ export class Store {
   }
 
   /**
-   * @param {Partial<V>} search
-   * @returns {Promise<import('@ucanto/interface').Result<V[], StoreGetError>>}
+   * @param {Q} search
+   * @param {Pageable} [options]
+   * @returns {Promise<import('@ucanto/interface').Result<ListSuccess<V>, StoreGetError>>}
    */
-  async query(search) {
+  async query(search, options) {
     if (!this.queryFn) {
       throw new Error('query not supported')
     }
-    const t = this.queryFn(this.items, search)
+    const t = this.queryFn(this.items, search, options)
+    return {
+      ok: t,
+    }
+  }
+
+  /**
+   * @param {K} key
+   * @param {Partial<V>} item
+   * @returns {Promise<import('@ucanto/interface').Result<V, StoreGetError>>}
+   */
+  async update(key, item) {
+    if (!this.updateFn) {
+      throw new Error('update not supported')
+    }
+    const t = this.updateFn(this.items, key, item)
     if (!t) {
       return {
         error: new RecordNotFound('not found'),
@@ -92,34 +112,6 @@ export class Store {
       ok: t,
     }
   }
-}
-
-/**
- * @template K
- * @template V
- * @implements {API.ReadableStreamStore<K,V>}
- */
-export class ReadableStreamStore {
-  /**
-   * @param {import('./types.js').ReadableStreamStoreOptions<K, V>} options
-   */
-  constructor(options) {
-    /** @type {Set<V>} */
-    this.items = new Set()
-    this.streamFn = options.streamFn
-  }
-
-  /**
-   * @param {V} record
-   * @returns {Promise<import('@ucanto/interface').Result<{}, StorePutError>>}
-   */
-  async put(record) {
-    this.items.add(record)
-
-    return Promise.resolve({
-      ok: {},
-    })
-  }
 
   /**
    * @param {K} item
@@ -127,7 +119,7 @@ export class ReadableStreamStore {
    */
   async stream(item) {
     if (!this.streamFn) {
-      throw new Error('get not supported')
+      throw new Error('stream not supported')
     }
     const t = this.streamFn(this.items, item)
     if (!t) {
@@ -144,47 +136,12 @@ export class ReadableStreamStore {
 /**
  * @template K
  * @template V
- * @implements {API.UpdatableStore<K,V>}
- * @extends {Store<K, V>}
+ * @template Q
+ * @implements {API.Store<K, V>}
+ * @implements {API.UpdatableStore<K, V>}
+ * @implements {API.QueryableStore<Q, V>}
  */
-export class UpdatableStore extends Store {
-  /**
-   * @param {import('./types.js').UpdatableStoreOptions<K, V>} options
-   */
-  constructor(options) {
-    super(options)
-
-    this.updateFn = options.updateFn
-  }
-
-  /**
-   * @param {K} key
-   * @param {Partial<V>} item
-   * @returns {Promise<import('@ucanto/interface').Result<V, StoreGetError>>}
-   */
-  async update(key, item) {
-    if (!this.updateFn) {
-      throw new Error('query not supported')
-    }
-
-    const t = this.updateFn(this.items, key, item)
-    if (!t) {
-      return {
-        error: new RecordNotFound('not found'),
-      }
-    }
-    return {
-      ok: t,
-    }
-  }
-}
-
-/**
- * @template K
- * @template V
- * @extends {UpdatableStore<K, V>}
- */
-export class FailingStore extends UpdatableStore {
+export class FailingStore {
   /**
    * @param {V} record
    */
@@ -215,8 +172,8 @@ export class FailingStore extends UpdatableStore {
   }
 
   /**
-   * @param {Partial<V>} search
-   * @returns {Promise<import('@ucanto/interface').Result<V[], StoreGetError>>}
+   * @param {Q} search
+   * @returns {Promise<import('@ucanto/interface').Result<ListSuccess<V>, StoreGetError>>}
    */
   async query(search) {
     return {

--- a/packages/filecoin-api/test/context/store.js
+++ b/packages/filecoin-api/test/context/store.js
@@ -22,7 +22,7 @@ import { StoreOperationFailed, RecordNotFound } from '../../src/errors.js'
  */
 export class Store {
   /**
-   * @param {import('./types.js').StoreOptions<K, V> & Partial<import('./types.js').UpdatableStoreOptions<K, V>> & Partial<import('./types.js').QueryableStoreOptions<Q, V>> & Partial<import('./types.js').ReadableStreamStoreOptions<K, V>>} options
+   * @param {import('./types.js').StoreOptions<K, V> & import('./types.js').UpdatableStoreOptions<K, V> & import('./types.js').QueryableStoreOptions<Q, V> & import('./types.js').ReadableStreamStoreOptions<K, V>} options
    */
   constructor(options) {
     /** @type {Set<V>} */
@@ -51,6 +51,9 @@ export class Store {
    * @returns {Promise<import('@ucanto/interface').Result<V, StoreGetError>>}
    */
   async get(item) {
+    if (!this.getFn) {
+      throw new Error('get not supported')
+    }
     const t = this.getFn(this.items, item)
     if (!t) {
       return {
@@ -67,6 +70,9 @@ export class Store {
    * @returns {Promise<import('@ucanto/interface').Result<boolean, StoreGetError>>}
    */
   async has(item) {
+    if (!this.getFn) {
+      throw new Error('has not supported')
+    }
     const t = this.getFn(this.items, item)
     if (!t) {
       return {

--- a/packages/filecoin-api/test/context/types.ts
+++ b/packages/filecoin-api/test/context/types.ts
@@ -1,12 +1,17 @@
+import { Pageable, ListSuccess } from '../../src/types.js'
+
 export interface StoreOptions<K, V> {
-  getFn?: (items: Set<V>, item: K) => V | undefined
-  queryFn?: (items: Set<V>, item: Partial<V>) => V[]
+  getFn: (items: Set<V>, item: K) => V | undefined
 }
 
-export interface UpdatableStoreOptions<K, V> extends StoreOptions<K, V> {
-  updateFn?: (items: Set<V>, key: K, item: Partial<V>) => V
+export interface QueryableStoreOptions<Q, V> {
+  queryFn: (items: Set<V>, query: Q, options?: Pageable) => ListSuccess<V>
 }
 
-export interface ReadableStreamStoreOptions<K, V> extends StoreOptions<K, V> {
-  streamFn?: (items: Set<V>, item: K) => ReadableStream<V> | undefined
+export interface UpdatableStoreOptions<K, V> {
+  updateFn: (items: Set<V>, key: K, item: Partial<V>) => V
+}
+
+export interface ReadableStreamStoreOptions<K, V> {
+  streamFn: (items: Set<V>, item: K) => ReadableStream<V> | undefined
 }

--- a/packages/filecoin-api/test/context/types.ts
+++ b/packages/filecoin-api/test/context/types.ts
@@ -1,17 +1,17 @@
 import { Pageable, ListSuccess } from '../../src/types.js'
 
 export interface StoreOptions<K, V> {
-  getFn: (items: Set<V>, item: K) => V | undefined
+  getFn?: (items: Set<V>, item: K) => V | undefined
 }
 
 export interface QueryableStoreOptions<Q, V> {
-  queryFn: (items: Set<V>, query: Q, options?: Pageable) => ListSuccess<V>
+  queryFn?: (items: Set<V>, query: Q, options?: Pageable) => ListSuccess<V>
 }
 
 export interface UpdatableStoreOptions<K, V> {
-  updateFn: (items: Set<V>, key: K, item: Partial<V>) => V
+  updateFn?: (items: Set<V>, key: K, item: Partial<V>) => V
 }
 
 export interface ReadableStreamStoreOptions<K, V> {
-  streamFn: (items: Set<V>, item: K) => ReadableStream<V> | undefined
+  streamFn?: (items: Set<V>, item: K) => ReadableStream<V> | undefined
 }

--- a/packages/filecoin-api/test/events/aggregator.js
+++ b/packages/filecoin-api/test/events/aggregator.js
@@ -12,7 +12,6 @@ import { FailingStore } from '../context/store.js'
 import { FailingQueue } from '../context/queue.js'
 import { mockService } from '../context/mocks.js'
 import { getConnection } from '../context/service.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import { randomAggregate, randomCargo } from '../utils.js'
 import {
   QueueOperationErrorName,
@@ -81,7 +80,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        pieceStore: getStoreImplementations(FailingStore).aggregator.pieceStore,
+        pieceStore: new FailingStore(),
       })
     ),
   'handles pieces insert batch successfully': async (assert, context) => {
@@ -143,8 +142,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        bufferStore:
-          getStoreImplementations(FailingStore).aggregator.bufferStore,
+        bufferStore: new FailingStore(),
       })
     ),
   'handles piece insert event errors when fails to access buffer queue':
@@ -568,8 +566,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        bufferStore:
-          getStoreImplementations(FailingStore).aggregator.bufferStore,
+        bufferStore: new FailingStore(),
       })
     ),
   'handles buffer queue message errors when fails to put message in buffer queue':
@@ -732,8 +729,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        aggregateStore:
-          getStoreImplementations(FailingStore).aggregator.aggregateStore,
+        aggregateStore: new FailingStore(),
       })
     ),
   'handles aggregate insert to queue piece accept successfully': async (
@@ -859,8 +855,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        bufferStore:
-          getStoreImplementations(FailingStore).aggregator.bufferStore,
+        bufferStore: new FailingStore(),
       })
     ),
   'handles aggregate insert event to piece accept queue errors when fails to add to piece accept queue':
@@ -1015,8 +1010,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        inclusionStore:
-          getStoreImplementations(FailingStore).aggregator.inclusionStore,
+        inclusionStore: new FailingStore(),
       })
     ),
   'handles inclusion insert to update piece store entry successfully': async (
@@ -1113,7 +1107,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        pieceStore: getStoreImplementations(FailingStore).aggregator.pieceStore,
+        pieceStore: new FailingStore(),
       })
     ),
   'handles inclusion insert to issue piece accept receipt successfully': async (
@@ -1346,8 +1340,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        bufferStore:
-          getStoreImplementations(FailingStore).aggregator.bufferStore,
+        bufferStore: new FailingStore(),
       })
     ),
 }

--- a/packages/filecoin-api/test/events/dealer.js
+++ b/packages/filecoin-api/test/events/dealer.js
@@ -11,7 +11,6 @@ import * as DealerEvents from '../../src/dealer/events.js'
 import { FailingStore } from '../context/store.js'
 import { mockService } from '../context/mocks.js'
 import { getConnection } from '../context/service.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import { randomAggregate } from '../utils.js'
 import { StoreOperationErrorName } from '../../src/errors.js'
 
@@ -111,7 +110,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        offerStore: getStoreImplementations(FailingStore).dealer.offerStore,
+        offerStore: new FailingStore(),
       })
     ),
   'handles aggregate update status event successfully': async (
@@ -357,8 +356,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        aggregateStore:
-          getStoreImplementations(FailingStore).dealer.aggregateStore,
+        aggregateStore: new FailingStore(),
       })
     ),
   'handles cron tick errors when deal tracker fails to respond':

--- a/packages/filecoin-api/test/events/storefront.js
+++ b/packages/filecoin-api/test/events/storefront.js
@@ -16,7 +16,6 @@ import { randomCargo, randomAggregate } from '../utils.js'
 import { FailingStore } from '../context/store.js'
 import { mockService } from '../context/mocks.js'
 import { getConnection } from '../context/service.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import { createInvocationsAndReceiptsForDealDataProofChain } from '../context/receipts.js'
 
 /**
@@ -128,7 +127,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        pieceStore: getStoreImplementations(FailingStore).storefront.pieceStore,
+        pieceStore: new FailingStore(),
       })
     ),
   'handles piece offer messages successfully': async (assert, context) => {
@@ -501,7 +500,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        pieceStore: getStoreImplementations(FailingStore).storefront.pieceStore,
+        pieceStore: new FailingStore(),
       })
     ),
 }

--- a/packages/filecoin-api/test/services/aggregator.js
+++ b/packages/filecoin-api/test/services/aggregator.js
@@ -11,7 +11,6 @@ import { createServer, connect } from '../../src/aggregator/service.js'
 import { randomAggregate, randomCargo } from '../utils.js'
 import { FailingStore } from '../context/store.js'
 import { FailingQueue } from '../context/queue.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import {
   QueueOperationErrorName,
   StoreOperationErrorName,
@@ -186,7 +185,7 @@ export const test = {
     },
     (context) => ({
       ...context,
-      pieceStore: getStoreImplementations(FailingStore).aggregator.pieceStore,
+      pieceStore: new FailingStore(),
     })
   ),
   'piece/offer fails if not able to add to piece queue': wichMockableContext(
@@ -386,8 +385,7 @@ export const test = {
       },
       (context) => ({
         ...context,
-        inclusionStore:
-          getStoreImplementations(FailingStore).aggregator.inclusionStore,
+        inclusionStore: new FailingStore(),
       })
     ),
   'piece/accept fails if not able to read from aggregate store':
@@ -441,8 +439,7 @@ export const test = {
       },
       (context) => ({
         ...context,
-        aggregateStore:
-          getStoreImplementations(FailingStore).aggregator.aggregateStore,
+        aggregateStore: new FailingStore(),
       })
     ),
 }

--- a/packages/filecoin-api/test/services/deal-tracker.js
+++ b/packages/filecoin-api/test/services/deal-tracker.js
@@ -7,7 +7,6 @@ import * as DealTrackerApi from '../../src/deal-tracker/api.js'
 import { createServer, connect } from '../../src/deal-tracker/service.js'
 import { randomCargo } from '../utils.js'
 import { FailingStore } from '../context/store.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import { StoreOperationErrorName } from '../../src/errors.js'
 
 /**
@@ -118,7 +117,7 @@ export const test = {
     },
     (context) => ({
       ...context,
-      dealStore: getStoreImplementations(FailingStore).dealTracker.dealStore,
+      dealStore: new FailingStore(),
     })
   ),
 }

--- a/packages/filecoin-api/test/services/dealer.js
+++ b/packages/filecoin-api/test/services/dealer.js
@@ -12,7 +12,6 @@ import { randomAggregate } from '../utils.js'
 import { FailingStore } from '../context/store.js'
 import { mockService } from '../context/mocks.js'
 import { getConnection } from '../context/service.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import {
   StoreOperationErrorName,
   UnsupportedCapabilityErrorName,
@@ -159,8 +158,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        aggregateStore:
-          getStoreImplementations(FailingStore).dealer.aggregateStore,
+        aggregateStore: new FailingStore(),
       })
     ),
   'aggregate/offer fails if not able to put to offer store':
@@ -195,7 +193,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        offerStore: getStoreImplementations(FailingStore).dealer.offerStore,
+        offerStore: new FailingStore(),
       })
     ),
   'aggregate/accept issues receipt with data aggregation proof': async (

--- a/packages/filecoin-api/test/services/storefront.js
+++ b/packages/filecoin-api/test/services/storefront.js
@@ -16,7 +16,6 @@ import {
 } from '../../src/errors.js'
 import { randomCargo, randomAggregate } from '../utils.js'
 import { createInvocationsAndReceiptsForDealDataProofChain } from '../context/receipts.js'
-import { getStoreImplementations } from '../context/store-implementations.js'
 import { FailingStore } from '../context/store.js'
 import { FailingQueue } from '../context/queue.js'
 import { mockService } from '../context/mocks.js'
@@ -239,7 +238,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        pieceStore: getStoreImplementations(FailingStore).storefront.pieceStore,
+        pieceStore: new FailingStore(),
       })
     ),
   'filecoin/submit must be invoked on service did': async (assert, context) => {
@@ -503,7 +502,7 @@ export const test = {
       },
       async (context) => ({
         ...context,
-        pieceStore: getStoreImplementations(FailingStore).storefront.pieceStore,
+        pieceStore: new FailingStore(),
       })
     ),
   'filecoin/info gets aggregate where piece was included together with deals and inclusion proof':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,20 +13,20 @@ importers:
         version: 1.4.7
       typedoc-plugin-missing-exports:
         specifier: ^2.1.0
-        version: 2.2.0(typedoc@0.25.13)
+        version: 2.2.0(typedoc@0.25.13(typescript@5.2.2))
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.15.3
         version: 0.15.3
       '@docusaurus/core':
         specifier: ^3.0.0
-        version: 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+        version: 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/preset-classic':
         specifier: ^3.0.0
-        version: 3.3.2(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
+        version: 3.3.2(@algolia/client-search@4.23.3)(@types/react@18.3.1)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
       docusaurus-plugin-typedoc:
         specifier: ^0.21.0
-        version: 0.21.0(typedoc-plugin-markdown@3.17.1)(typedoc@0.25.13)
+        version: 0.21.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.13(typescript@5.2.2)))(typedoc@0.25.13(typescript@5.2.2))
       lint-staged:
         specifier: ^13.2.0
         version: 13.3.0
@@ -41,7 +41,7 @@ importers:
         version: 0.25.13(typescript@5.2.2)
       typedoc-plugin-markdown:
         specifier: ^3.17.0
-        version: 3.17.1(typedoc@0.25.13)
+        version: 3.17.1(typedoc@0.25.13(typescript@5.2.2))
       typescript:
         specifier: 5.2.2
         version: 5.2.2
@@ -269,10 +269,10 @@ importers:
     dependencies:
       '@typescript-eslint/eslint-plugin':
         specifier: ^6.9.1
-        version: 6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.2.2)
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/parser':
         specifier: ^6.9.1
-        version: 6.21.0(eslint@8.57.0)(typescript@5.2.2)
+        version: 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       eslint:
         specifier: ^8.56.0
         version: 8.57.0
@@ -334,6 +334,9 @@ importers:
       '@web3-storage/filecoin-client':
         specifier: workspace:^
         version: link:../filecoin-client
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
       mocha:
         specifier: ^10.2.0
         version: 10.4.0
@@ -536,7 +539,7 @@ importers:
         version: link:../filecoin-client
       ipfs-utils:
         specifier: ^9.0.14
-        version: 9.0.14
+        version: 9.0.14(encoding@0.1.13)
       multiformats:
         specifier: ^12.1.2
         version: 12.1.3
@@ -1467,11 +1470,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/cssnano-preset@3.3.2':
     resolution: {integrity: sha512-+5+epLk/Rp4vFML4zmyTATNc3Is+buMAL6dNjrMWahdJCJlMWMPd/8YfU+2PA57t8mlSbhLJ7vAZVy54cd1vRQ==}
@@ -1487,22 +1485,12 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/module-type-aliases@3.3.2':
     resolution: {integrity: sha512-b/XB0TBJah5yKb4LYuJT4buFvL0MGAb0+vJDrJtlYMguRtsEBkf2nWl5xP7h4Dlw6ol0hsHrCYzJ50kNIOEclw==}
     peerDependencies:
       react: '*'
       react-dom: '*'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-content-blog@3.3.2':
     resolution: {integrity: sha512-fJU+dmqp231LnwDJv+BHVWft8pcUS2xVPZdeYH6/ibH1s2wQ/sLcmUrGWyIv/Gq9Ptj8XWjRPMghlxghuPPoxg==}
@@ -1510,11 +1498,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-content-docs@3.3.2':
     resolution: {integrity: sha512-Dm1ri2VlGATTN3VGk1ZRqdRXWa1UlFubjaEL6JaxaK7IIFqN/Esjpl+Xw10R33loHcRww/H76VdEeYayaL76eg==}
@@ -1522,11 +1505,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-content-pages@3.3.2':
     resolution: {integrity: sha512-EKc9fQn5H2+OcGER8x1aR+7URtAGWySUgULfqE/M14+rIisdrBstuEZ4lUPDRrSIexOVClML82h2fDS+GSb8Ew==}
@@ -1534,11 +1512,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-debug@3.3.2':
     resolution: {integrity: sha512-oBIBmwtaB+YS0XlmZ3gCO+cMbsGvIYuAKkAopoCh0arVjtlyPbejzPrHuCoRHB9G7abjNZw7zoONOR8+8LM5+Q==}
@@ -1546,11 +1519,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-google-analytics@3.3.2':
     resolution: {integrity: sha512-jXhrEIhYPSClMBK6/IA8qf1/FBoxqGXZvg7EuBax9HaK9+kL3L0TJIlatd8jQJOMtds8mKw806TOCc3rtEad1A==}
@@ -1558,11 +1526,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-google-gtag@3.3.2':
     resolution: {integrity: sha512-vcrKOHGbIDjVnNMrfbNpRQR1x6Jvcrb48kVzpBAOsKbj9rXZm/idjVAXRaewwobHdOrJkfWS/UJoxzK8wyLRBQ==}
@@ -1570,11 +1533,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-google-tag-manager@3.3.2':
     resolution: {integrity: sha512-ldkR58Fdeks0vC+HQ+L+bGFSJsotQsipXD+iKXQFvkOfmPIV6QbHRd7IIcm5b6UtwOiK33PylNS++gjyLUmaGw==}
@@ -1582,11 +1540,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/plugin-sitemap@3.3.2':
     resolution: {integrity: sha512-/ZI1+bwZBhAgC30inBsHe3qY9LOZS+79fRGkNdTcGHRMcdAp6Vw2pCd1gzlxd/xU+HXsNP6cLmTOrggmRp3Ujg==}
@@ -1594,11 +1547,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/preset-classic@3.3.2':
     resolution: {integrity: sha512-1SDS7YIUN1Pg3BmD6TOTjhB7RSBHJRpgIRKx9TpxqyDrJ92sqtZhomDc6UYoMMLQNF2wHFZZVGFjxJhw2VpL+Q==}
@@ -1606,19 +1554,11 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/react-loadable@6.0.0':
     resolution: {integrity: sha512-YMMxTUQV/QFSnbgrP3tjDzLHRg7vsbMn8e9HAa8o/1iXoiomo48b7sk/kkmWEuWNDPJVlKSJRB6Y2fHqdJk+SQ==}
     peerDependencies:
       react: '*'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@docusaurus/theme-classic@3.3.2':
     resolution: {integrity: sha512-gepHFcsluIkPb4Im9ukkiO4lXrai671wzS3cKQkY9BXQgdVwsdPf/KS0Vs4Xlb0F10fTz+T3gNjkxNEgSN9M0A==}
@@ -1626,11 +1566,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/theme-common@3.3.2':
     resolution: {integrity: sha512-kXqSaL/sQqo4uAMQ4fHnvRZrH45Xz2OdJ3ABXDS7YVGPSDTBC8cLebFrRR4YF9EowUHto1UC/EIklJZQMG/usA==}
@@ -1638,11 +1573,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/theme-search-algolia@3.3.2':
     resolution: {integrity: sha512-qLkfCl29VNBnF1MWiL9IyOQaHxUvicZp69hISyq/xMsNvFKHFOaOfk9xezYod2Q9xx3xxUh9t/QPigIei2tX4w==}
@@ -1650,11 +1580,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/theme-translations@3.3.2':
     resolution: {integrity: sha512-bPuiUG7Z8sNpGuTdGnmKl/oIPeTwKr0AXLGu9KaP6+UFfRZiyWbWE87ti97RrevB2ffojEdvchNujparR3jEZQ==}
@@ -1665,11 +1590,6 @@ packages:
     peerDependencies:
       react: ^18.0.0
       react-dom: ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   '@docusaurus/utils-common@3.3.2':
     resolution: {integrity: sha512-QWFTLEkPYsejJsLStgtmetMFIA3pM8EPexcZ4WZ7b++gO5jGVH7zsipREnCHzk6+eDgeaXfkR6UPaTt86bp8Og==}
@@ -1886,6 +1806,10 @@ packages:
   '@ipld/unixfs@2.2.0':
     resolution: {integrity: sha512-lDQ2eRhJlbFaBoO3bhOmDVCLmpOnhwtwbilqUgAAhbhoPSmLrnv7gsBuToZjXOdPaEGSL7apkmm6nFrcU6zh4Q==}
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
   '@istanbuljs/schema@0.1.3':
     resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
     engines: {node: '>=8'}
@@ -1930,9 +1854,6 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   '@multiformats/murmur3@2.1.8':
     resolution: {integrity: sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==}
@@ -1962,6 +1883,10 @@ packages:
 
   '@perma/map@1.0.3':
     resolution: {integrity: sha512-Bf5njk0fnJGTFE2ETntq0N1oJ6YdCPIpTDn3R3KYZJQdeYSOCNL7mBrFlGnbqav8YQhJA/p81pvHINX9vAtHkQ==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -2805,6 +2730,16 @@ packages:
   bytes@3.1.2:
     resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
     engines: {node: '>= 0.8'}
+
+  c8@10.1.2:
+    resolution: {integrity: sha512-Qr6rj76eSshu5CgRYvktW0uM0CFY0yi4Fd5D0duDXO6sYinyopmftUiJVuzBQxQcwQLor7JWDVRP+dUfCmzgJw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      monocart-coverage-reports: ^2
+    peerDependenciesMeta:
+      monocart-coverage-reports:
+        optional: true
 
   c8@7.14.0:
     resolution: {integrity: sha512-i04rtkkcNcCf7zsQcSv/T9EbUn4RXQ6mropeMcjFOsQXQ0iGLAr/xT6TImQg4+U9hmNpN9XdvPkjUL1IzbgxJw==}
@@ -3788,6 +3723,10 @@ packages:
     resolution: {integrity: sha512-dCIq9FpEcyQyXKCkyzmlPTFNgrCzPudOe+mhvJU5zAtlBnGVy2yKxtfsxK2tQBThwq225jcvBjpw1Gr40uzZCA==}
     engines: {node: '>=8.0.0'}
 
+  foreground-child@3.2.1:
+    resolution: {integrity: sha512-PXUUyLqrR2XCWICfv6ukppP96sdFwWbNEnfEMt7jNsISjMsvaLNinAHNDYyvkyU+SZG2BTSbT5NjG+vZslfGTA==}
+    engines: {node: '>=14'}
+
   fork-ts-checker-webpack-plugin@6.5.3:
     resolution: {integrity: sha512-SbH/l9ikmMWycd5puHJKTkZJKddF4iRLyW3DeZ08HTI7NGyLS38MXd/KGgeWumQO7YNQbW2u/NtPT2YowbPaGQ==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
@@ -3896,6 +3835,10 @@ packages:
 
   glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
+
+  glob@10.4.5:
+    resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -4570,6 +4513,9 @@ packages:
   it-to-stream@1.0.0:
     resolution: {integrity: sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==}
 
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jest-util@29.7.0:
     resolution: {integrity: sha512-z6EbKajIpqGKU56y5KBUgy1dt1ihhQJgWzUlZHArA/+X2ad7Cb5iF+AK1EWVL/Bo7Rz9uurpqw6SiBCefUbCGA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -4781,6 +4727,9 @@ packages:
   lowercase-keys@3.0.0:
     resolution: {integrity: sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -5114,6 +5063,10 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
+  minipass@7.1.2:
+    resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
   mocha@10.4.0:
     resolution: {integrity: sha512-eqhGB8JKapEYcC4ytX/xrzKforgEc3j1pGlAXVy3eRwrtAy5/nIfT1SvgGzfN0XZZxeLq0aQWkOUAmqIJiv+bA==}
     engines: {node: '>= 14.0.0'}
@@ -5285,7 +5238,6 @@ packages:
 
   one-webcrypto@https://codeload.github.com/web3-storage/one-webcrypto/tar.gz/5148cd14d5489a8ac4cd38223870e02db15a2382:
     resolution: {tarball: https://codeload.github.com/web3-storage/one-webcrypto/tar.gz/5148cd14d5489a8ac4cd38223870e02db15a2382}
-    name: one-webcrypto
     version: 1.0.3
 
   onetime@5.1.2:
@@ -5399,6 +5351,9 @@ packages:
     resolution: {integrity: sha512-lwx6u1CotQYPVju77R+D0vFomni/AqRfqLmqQ8hekklqZ6gAY9rONh7lBQ0uxWMkC2AuX9b2DVAl8To0NyP1JA==}
     engines: {node: '>=12'}
 
+  package-json-from-dist@1.0.0:
+    resolution: {integrity: sha512-dATvCeZN/8wQsGywez1mzHtTlP22H8OEfPrVMLNr4/eGa+ijtLn/6M5f0dY8UKNrC2O9UCU6SSoG3qRKnt7STw==}
+
   package-json@8.1.1:
     resolution: {integrity: sha512-cbH9IAIJHNj9uXi196JVsRlt7cHKak6u/e6AkL/bkRelZ7rlL3X1YKxsZwa36xipOEKAsdtmaG6aAJoM1fx2zA==}
     engines: {node: '>=14.16'}
@@ -5477,6 +5432,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   path-to-regexp@0.1.7:
     resolution: {integrity: sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==}
@@ -5813,9 +5772,6 @@ packages:
     resolution: {integrity: sha512-Rdf+HzBLR7KYjzpJ1rSoxT9ioO85nZngQEoFIhL07XhtJHlCU3SOz0GJ6+qvMyQe0Se+BV3qpe6Yd/NmQF5Juw==}
     peerDependencies:
       react: '>=16.0.0'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   prismjs@1.29.0:
     resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
@@ -5906,6 +5862,11 @@ packages:
       typescript:
         optional: true
 
+  react-dom@18.3.1:
+    resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
+    peerDependencies:
+      react: ^18.3.1
+
   react-error-overlay@6.0.11:
     resolution: {integrity: sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg==}
 
@@ -5917,19 +5878,11 @@ packages:
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
       react-dom: ^16.6.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
 
   react-helmet-async@2.0.5:
     resolution: {integrity: sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==}
     peerDependencies:
       react: ^16.6.0 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -5939,9 +5892,6 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       react: ^16.13.1 || ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   react-loadable-ssr-addon-v5-slorber@1.0.1:
     resolution: {integrity: sha512-lq3Lyw1lGku8zUEJPDxsNm1AfYHBrO9Y1+olAYwpUJ2IGFBskM0DMKok97A6LWUpHm+o7IvQBOWu9MLenp9Z+A==}
@@ -5949,9 +5899,6 @@ packages:
     peerDependencies:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
-    peerDependenciesMeta:
-      react-loadable:
-        optional: true
 
   react-native-fetch-api@3.0.0:
     resolution: {integrity: sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==}
@@ -5961,27 +5908,16 @@ packages:
     peerDependencies:
       react: '>=15'
       react-router: '>=5'
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-router:
-        optional: true
 
   react-router-dom@5.3.4:
     resolution: {integrity: sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==}
     peerDependencies:
       react: '>=15'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   react-router@5.3.4:
     resolution: {integrity: sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==}
     peerDependencies:
       react: '>=15'
-    peerDependenciesMeta:
-      react:
-        optional: true
 
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
@@ -6183,6 +6119,9 @@ packages:
 
   sax@1.3.0:
     resolution: {integrity: sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==}
+
+  scheduler@0.23.2:
+    resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
 
   schema-utils@2.7.0:
     resolution: {integrity: sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==}
@@ -6589,6 +6528,10 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  test-exclude@7.0.1:
+    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
+    engines: {node: '>=18'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -8043,19 +7986,21 @@ snapshots:
 
   '@docsearch/css@3.6.0': {}
 
-  '@docsearch/react@3.6.0(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react@18.3.1)(search-insights@2.13.0)':
+  '@docsearch/react@3.6.0(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)':
     dependencies:
       '@algolia/autocomplete-core': 1.9.3(@algolia/client-search@4.23.3)(algoliasearch@4.23.3)(search-insights@2.13.0)
       '@algolia/autocomplete-preset-algolia': 1.9.3(@algolia/client-search@4.23.3)(algoliasearch@4.23.3)
       '@docsearch/css': 3.6.0
-      '@types/react': 18.3.1
       algoliasearch: 4.23.3
+    optionalDependencies:
+      '@types/react': 18.3.1
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       search-insights: 2.13.0
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/core@3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@babel/core': 7.24.5
       '@babel/generator': 7.24.5
@@ -8069,10 +8014,10 @@ snapshots:
       '@babel/traverse': 7.24.5
       '@docusaurus/cssnano-preset': 3.3.2
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       autoprefixer: 10.4.19(postcss@8.4.38)
       babel-loader: 9.1.3(@babel/core@7.24.5)(webpack@5.91.0)
       babel-plugin-dynamic-import-node: 2.3.3
@@ -8106,12 +8051,13 @@ snapshots:
       postcss-loader: 7.3.4(postcss@8.4.38)(typescript@5.2.2)(webpack@5.91.0)
       prompts: 2.4.2
       react: 18.3.1
-      react-dev-utils: 12.0.1(typescript@5.2.2)(webpack@5.91.0)
-      react-helmet-async: 1.3.0(react@18.3.1)
+      react-dev-utils: 12.0.1(eslint@8.57.0)(typescript@5.2.2)(webpack@5.91.0)
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
-      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.91.0)
+      react-loadable-ssr-addon-v5-slorber: 1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.91.0)
       react-router: 5.3.4(react@18.3.1)
-      react-router-config: 5.1.1(react-router@5.3.4)(react@18.3.1)
+      react-router-config: 5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
       rtl-detect: 1.1.2
       semver: 7.6.0
@@ -8120,7 +8066,7 @@ snapshots:
       terser-webpack-plugin: 5.3.10(webpack@5.91.0)
       tslib: 2.6.2
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.91.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.91.0))(webpack@5.91.0)
       webpack: 5.91.0
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 4.15.2(webpack@5.91.0)
@@ -8157,11 +8103,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.6.2
 
-  '@docusaurus/mdx-loader@3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/mdx-loader@3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       '@mdx-js/mdx': 3.0.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -8172,6 +8118,7 @@ snapshots:
       mdast-util-mdx: 3.0.0
       mdast-util-to-string: 4.0.0
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       rehype-raw: 7.0.0
       remark-directive: 3.0.0
       remark-emoji: 4.0.1
@@ -8181,7 +8128,7 @@ snapshots:
       tslib: 2.6.2
       unified: 11.0.4
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.91.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.91.0))(webpack@5.91.0)
       vfile: 6.0.1
       webpack: 5.91.0
     transitivePeerDependencies:
@@ -8193,14 +8140,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/module-type-aliases@3.3.2(react@18.3.1)':
+  '@docusaurus/module-type-aliases@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
-      '@docusaurus/types': 3.3.2(react@18.3.1)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/history': 4.7.11
       '@types/react': 18.3.1
       '@types/react-router-config': 5.0.11
       '@types/react-router-dom': 5.3.3
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 2.0.5(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
     transitivePeerDependencies:
@@ -8210,20 +8158,21 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-blog@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.2.0
       lodash: 4.17.21
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       reading-time: 1.5.0
       srcset: 4.0.0
       tslib: 2.6.2
@@ -8248,22 +8197,23 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-docs@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/module-type-aliases': 3.3.2(react@18.3.1)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.2.0
       js-yaml: 4.1.0
       lodash: 4.17.21
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
       utility-types: 3.11.0
       webpack: 5.91.0
@@ -8285,15 +8235,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-content-pages@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       fs-extra: 11.2.0
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
       webpack: 5.91.0
     transitivePeerDependencies:
@@ -8314,13 +8265,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-debug@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       fs-extra: 11.2.0
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-json-view-lite: 1.4.0(react@18.3.1)
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -8341,12 +8293,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-analytics@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@parcel/css'
@@ -8366,13 +8319,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-gtag@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@parcel/css'
@@ -8392,12 +8346,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-google-tag-manager@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
     transitivePeerDependencies:
       - '@parcel/css'
@@ -8417,16 +8372,17 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.3.2(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/plugin-sitemap@3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       fs-extra: 11.2.0
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       sitemap: 7.1.1
       tslib: 2.6.2
     transitivePeerDependencies:
@@ -8447,22 +8403,23 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.3.2(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)':
+  '@docusaurus/preset-classic@3.3.2(@algolia/client-search@4.23.3)(@types/react@18.3.1)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-blog': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-debug': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-analytics': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-gtag': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-google-tag-manager': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-sitemap': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-classic': 3.3.2(@types/react@18.3.1)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-search-algolia': 3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2)(@types/react@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
-      '@docusaurus/types': 3.3.2(react@18.3.1)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-debug': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-analytics': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-gtag': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-google-tag-manager': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-sitemap': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-classic': 3.3.2(@types/react@18.3.1)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-search-algolia': 3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.1)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
       - '@algolia/client-search'
       - '@parcel/css'
@@ -8489,20 +8446,20 @@ snapshots:
       '@types/react': 18.3.1
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.3.2(@types/react@18.3.1)(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/theme-classic@3.3.2(@types/react@18.3.1)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/module-type-aliases': 3.3.2(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       '@mdx-js/react': 3.0.1(@types/react@18.3.1)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.0
@@ -8513,6 +8470,7 @@ snapshots:
       prism-react-renderer: 2.3.1(react@18.3.1)
       prismjs: 1.29.0
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-router-dom: 5.3.4(react@18.3.1)
       rtlcss: 4.1.1
       tslib: 2.6.2
@@ -8536,15 +8494,15 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)':
+  '@docusaurus/theme-common@3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/module-type-aliases': 3.3.2(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-docs': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/plugin-content-pages': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
+      '@docusaurus/mdx-loader': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/module-type-aliases': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@docusaurus/plugin-content-blog': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-pages': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
       '@types/react': 18.3.1
       '@types/react-router-config': 5.0.11
@@ -8552,6 +8510,7 @@ snapshots:
       parse-numeric-range: 1.3.0
       prism-react-renderer: 2.3.1(react@18.3.1)
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
       utility-types: 3.11.0
     transitivePeerDependencies:
@@ -8573,16 +8532,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2)(@types/react@18.3.1)(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)':
+  '@docusaurus/theme-search-algolia@3.3.2(@algolia/client-search@4.23.3)(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@types/react@18.3.1)(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)(typescript@5.2.2)':
     dependencies:
-      '@docsearch/react': 3.6.0(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react@18.3.1)(search-insights@2.13.0)
-      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+      '@docsearch/react': 3.6.0(@algolia/client-search@4.23.3)(@types/react@18.3.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.13.0)
+      '@docusaurus/core': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/plugin-content-docs': 3.3.2(react@18.3.1)(typescript@5.2.2)
-      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2)(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/plugin-content-docs': 3.3.2(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
+      '@docusaurus/theme-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(eslint@8.57.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/theme-translations': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-validation': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
       algoliasearch: 4.23.3
       algoliasearch-helper: 3.19.0(algoliasearch@4.23.3)
       clsx: 2.1.1
@@ -8590,6 +8549,7 @@ snapshots:
       fs-extra: 11.2.0
       lodash: 4.17.21
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       tslib: 2.6.2
       utility-types: 3.11.0
     transitivePeerDependencies:
@@ -8619,7 +8579,7 @@ snapshots:
       fs-extra: 11.2.0
       tslib: 2.6.2
 
-  '@docusaurus/types@3.3.2(react@18.3.1)':
+  '@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@mdx-js/mdx': 3.0.1
       '@types/history': 4.7.11
@@ -8627,7 +8587,8 @@ snapshots:
       commander: 5.1.0
       joi: 17.13.1
       react: 18.3.1
-      react-helmet-async: 1.3.0(react@18.3.1)
+      react-dom: 18.3.1(react@18.3.1)
+      react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       utility-types: 3.11.0
       webpack: 5.91.0
       webpack-merge: 5.10.0
@@ -8638,16 +8599,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils-common@3.3.2(@docusaurus/types@3.3.2)':
+  '@docusaurus/utils-common@3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
-      '@docusaurus/types': 3.3.2(react@18.3.1)
       tslib: 2.6.2
+    optionalDependencies:
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@docusaurus/utils-validation@3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)':
+  '@docusaurus/utils-validation@3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)':
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
+      '@docusaurus/utils': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       joi: 17.13.1
       js-yaml: 4.1.0
       tslib: 2.6.2
@@ -8660,11 +8622,10 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.3.2(@docusaurus/types@3.3.2)(typescript@5.2.2)':
+  '@docusaurus/utils@3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.2.2)':
     dependencies:
       '@docusaurus/logger': 3.3.2
-      '@docusaurus/types': 3.3.2(react@18.3.1)
-      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2)
+      '@docusaurus/utils-common': 3.3.2(@docusaurus/types@3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@svgr/webpack': 8.1.0(typescript@5.2.2)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.91.0)
@@ -8680,8 +8641,10 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.6.2
-      url-loader: 4.1.1(file-loader@6.2.0)(webpack@5.91.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.91.0))(webpack@5.91.0)
       webpack: 5.91.0
+    optionalDependencies:
+      '@docusaurus/types': 3.3.2(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     transitivePeerDependencies:
       - '@swc/core'
       - esbuild
@@ -8840,6 +8803,15 @@ snapshots:
       protobufjs: 7.2.6
       rabin-rs: 2.1.0
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.1.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
   '@istanbuljs/schema@0.1.3': {}
 
   '@jest/schemas@29.6.3':
@@ -8942,6 +8914,9 @@ snapshots:
     dependencies:
       '@multiformats/murmur3': 2.1.8
       murmurhash3js-revisited: 3.0.0
+
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -9095,7 +9070,7 @@ snapshots:
       '@babel/types': 7.24.5
       entities: 4.5.0
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0)':
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.2.2))':
     dependencies:
       '@babel/core': 7.24.5
       '@svgr/babel-preset': 8.1.0(@babel/core@7.24.5)
@@ -9105,7 +9080,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0)(typescript@5.2.2)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.2.2))(typescript@5.2.2)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.2.2)
       cosmiconfig: 8.3.6(typescript@5.2.2)
@@ -9122,8 +9097,8 @@ snapshots:
       '@babel/preset-react': 7.24.1(@babel/core@7.24.5)
       '@babel/preset-typescript': 7.24.1(@babel/core@7.24.5)
       '@svgr/core': 8.1.0(typescript@5.2.2)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0)
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0)(typescript@5.2.2)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.2.2))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.2.2))(typescript@5.2.2)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -9340,13 +9315,13 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0)(eslint@8.57.0)(typescript@5.2.2)':
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3))(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.10.0
-      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/scope-manager': 6.21.0
-      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
@@ -9354,20 +9329,22 @@ snapshots:
       ignore: 5.3.1
       natural-compare: 1.4.0
       semver: 7.6.0
-      ts-api-utils: 1.3.0(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.2.2)':
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
-      typescript: 5.2.2
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
@@ -9376,20 +9353,21 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
-  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.2.2)':
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
-      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.0)(typescript@5.3.3)
       debug: 4.3.4(supports-color@8.1.1)
       eslint: 8.57.0
-      ts-api-utils: 1.3.0(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
   '@typescript-eslint/types@6.21.0': {}
 
-  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.2.2)':
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.3.3)':
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
@@ -9398,19 +9376,20 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.3
       semver: 7.6.0
-      ts-api-utils: 1.3.0(typescript@5.2.2)
-      typescript: 5.2.2
+      ts-api-utils: 1.3.0(typescript@5.3.3)
+    optionalDependencies:
+      typescript: 5.3.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.2.2)':
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.0)(typescript@5.3.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.57.0)
       '@types/json-schema': 7.0.15
       '@types/semver': 7.5.8
       '@typescript-eslint/scope-manager': 6.21.0
       '@typescript-eslint/types': 6.21.0
-      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       eslint: 8.57.0
       semver: 7.6.0
     transitivePeerDependencies:
@@ -9681,7 +9660,7 @@ snapshots:
       indent-string: 5.0.0
 
   ajv-formats@2.1.1(ajv@8.13.0):
-    dependencies:
+    optionalDependencies:
       ajv: 8.13.0
 
   ajv-keywords@3.5.2(ajv@6.12.6):
@@ -9982,6 +9961,20 @@ snapshots:
   bytes@3.0.0: {}
 
   bytes@3.1.2: {}
+
+  c8@10.1.2:
+    dependencies:
+      '@bcoe/v8-coverage': 0.2.3
+      '@istanbuljs/schema': 0.1.3
+      find-up: 5.0.0
+      foreground-child: 3.2.1
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-reports: 3.1.7
+      test-exclude: 7.0.1
+      v8-to-istanbul: 9.2.0
+      yargs: 17.7.2
+      yargs-parser: 21.1.1
 
   c8@7.14.0:
     dependencies:
@@ -10344,6 +10337,7 @@ snapshots:
       js-yaml: 4.1.0
       parse-json: 5.2.0
       path-type: 4.0.0
+    optionalDependencies:
       typescript: 5.2.2
 
   cpy@11.0.1:
@@ -10387,18 +10381,20 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.4.38)
       postcss-value-parser: 4.2.0
       semver: 7.6.0
+    optionalDependencies:
       webpack: 5.91.0
 
   css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.91.0):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      clean-css: 5.3.3
       cssnano: 6.1.2(postcss@8.4.38)
       jest-worker: 29.7.0
       postcss: 8.4.38
       schema-utils: 4.2.0
       serialize-javascript: 6.0.2
       webpack: 5.91.0
+    optionalDependencies:
+      clean-css: 5.3.3
 
   css-select@4.3.0:
     dependencies:
@@ -10522,6 +10518,7 @@ snapshots:
   debug@4.3.4(supports-color@8.1.1):
     dependencies:
       ms: 2.1.2
+    optionalDependencies:
       supports-color: 8.1.1
 
   decamelize@4.0.0: {}
@@ -10647,10 +10644,10 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
-  docusaurus-plugin-typedoc@0.21.0(typedoc-plugin-markdown@3.17.1)(typedoc@0.25.13):
+  docusaurus-plugin-typedoc@0.21.0(typedoc-plugin-markdown@3.17.1(typedoc@0.25.13(typescript@5.2.2)))(typedoc@0.25.13(typescript@5.2.2)):
     dependencies:
       typedoc: 0.25.13(typescript@5.2.2)
-      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.13)
+      typedoc-plugin-markdown: 3.17.1(typedoc@0.25.13(typescript@5.2.2))
 
   dom-converter@0.2.0:
     dependencies:
@@ -11213,7 +11210,12 @@ snapshots:
       cross-spawn: 7.0.3
       signal-exit: 3.0.7
 
-  fork-ts-checker-webpack-plugin@6.5.3(typescript@5.2.2)(webpack@5.91.0):
+  foreground-child@3.2.1:
+    dependencies:
+      cross-spawn: 7.0.3
+      signal-exit: 4.1.0
+
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@8.57.0)(typescript@5.2.2)(webpack@5.91.0):
     dependencies:
       '@babel/code-frame': 7.24.2
       '@types/json-schema': 7.0.15
@@ -11230,6 +11232,8 @@ snapshots:
       tapable: 1.1.3
       typescript: 5.2.2
       webpack: 5.91.0
+    optionalDependencies:
+      eslint: 8.57.0
 
   form-data-encoder@2.1.4: {}
 
@@ -11311,6 +11315,15 @@ snapshots:
       is-glob: 4.0.3
 
   glob-to-regexp@0.4.1: {}
+
+  glob@10.4.5:
+    dependencies:
+      foreground-child: 3.2.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.4
+      minipass: 7.1.2
+      package-json-from-dist: 1.0.0
+      path-scurry: 1.11.1
 
   glob@7.2.3:
     dependencies:
@@ -11634,6 +11647,7 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.1
+    optionalDependencies:
       webpack: 5.91.0
 
   htmlparser2@6.1.0:
@@ -11673,12 +11687,13 @@ snapshots:
 
   http-proxy-middleware@2.0.6(@types/express@4.17.21):
     dependencies:
-      '@types/express': 4.17.21
       '@types/http-proxy': 1.17.14
       http-proxy: 1.18.1
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.5
+    optionalDependencies:
+      '@types/express': 4.17.21
     transitivePeerDependencies:
       - debug
 
@@ -11805,7 +11820,7 @@ snapshots:
       err-code: 3.0.1
       protobufjs: 7.2.6
 
-  ipfs-utils@9.0.14:
+  ipfs-utils@9.0.14(encoding@0.1.13):
     dependencies:
       any-signal: 3.0.1
       browser-readablestream-to-it: 1.0.3
@@ -11819,8 +11834,8 @@ snapshots:
       it-to-stream: 1.0.0
       merge-options: 3.0.4
       nanoid: 3.3.7
-      native-fetch: 3.0.0(node-fetch@2.7.0)
-      node-fetch: 2.7.0
+      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      node-fetch: 2.7.0(encoding@0.1.13)
       react-native-fetch-api: 3.0.0
       stream-to-it: 0.2.4
     transitivePeerDependencies:
@@ -12070,6 +12085,12 @@ snapshots:
       p-fifo: 1.0.0
       readable-stream: 3.6.2
 
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jest-util@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
@@ -12277,6 +12298,8 @@ snapshots:
       tslib: 2.6.2
 
   lowercase-keys@3.0.0: {}
+
+  lru-cache@10.4.3: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -12883,6 +12906,8 @@ snapshots:
 
   minimist@1.2.8: {}
 
+  minipass@7.1.2: {}
+
   mocha@10.4.0:
     dependencies:
       ansi-colors: 4.1.1
@@ -12941,9 +12966,9 @@ snapshots:
 
   nanoid@5.0.7: {}
 
-  native-fetch@3.0.0(node-fetch@2.7.0):
+  native-fetch@3.0.0(node-fetch@2.7.0(encoding@0.1.13)):
     dependencies:
-      node-fetch: 2.7.0
+      node-fetch: 2.7.0(encoding@0.1.13)
 
   natural-compare@1.4.0: {}
 
@@ -12973,9 +12998,11 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-fetch@2.7.0:
+  node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
+    optionalDependencies:
+      encoding: 0.1.13
 
   node-forge@1.3.1: {}
 
@@ -13169,6 +13196,8 @@ snapshots:
     dependencies:
       p-timeout: 6.1.2
 
+  package-json-from-dist@1.0.0: {}
+
   package-json@8.1.1:
     dependencies:
       got: 12.6.1
@@ -13247,6 +13276,11 @@ snapshots:
   path-key@4.0.0: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.2
 
   path-to-regexp@0.1.7: {}
 
@@ -13660,7 +13694,7 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-dev-utils@12.0.1(typescript@5.2.2)(webpack@5.91.0):
+  react-dev-utils@12.0.1(eslint@8.57.0)(typescript@5.2.2)(webpack@5.91.0):
     dependencies:
       '@babel/code-frame': 7.24.2
       address: 1.2.2
@@ -13671,7 +13705,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(typescript@5.2.2)(webpack@5.91.0)
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@8.57.0)(typescript@5.2.2)(webpack@5.91.0)
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -13686,23 +13720,31 @@ snapshots:
       shell-quote: 1.8.1
       strip-ansi: 6.0.1
       text-table: 0.2.0
-      typescript: 5.2.2
       webpack: 5.91.0
+    optionalDependencies:
+      typescript: 5.2.2
     transitivePeerDependencies:
       - eslint
       - supports-color
       - vue-template-compiler
 
+  react-dom@18.3.1(react@18.3.1):
+    dependencies:
+      loose-envify: 1.4.0
+      react: 18.3.1
+      scheduler: 0.23.2
+
   react-error-overlay@6.0.11: {}
 
   react-fast-compare@3.2.2: {}
 
-  react-helmet-async@1.3.0(react@18.3.1):
+  react-helmet-async@1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.5
       invariant: 2.2.4
       prop-types: 15.8.1
       react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
@@ -13719,7 +13761,7 @@ snapshots:
     dependencies:
       react: 18.3.1
 
-  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0)(webpack@5.91.0):
+  react-loadable-ssr-addon-v5-slorber@1.0.1(@docusaurus/react-loadable@6.0.0(react@18.3.1))(webpack@5.91.0):
     dependencies:
       '@babel/runtime': 7.24.5
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
@@ -13729,7 +13771,7 @@ snapshots:
     dependencies:
       p-defer: 3.0.0
 
-  react-router-config@5.1.1(react-router@5.3.4)(react@18.3.1):
+  react-router-config@5.1.1(react-router@5.3.4(react@18.3.1))(react@18.3.1):
     dependencies:
       '@babel/runtime': 7.24.5
       react: 18.3.1
@@ -14015,6 +14057,10 @@ snapshots:
   safer-buffer@2.1.2: {}
 
   sax@1.3.0: {}
+
+  scheduler@0.23.2:
+    dependencies:
+      loose-envify: 1.4.0
 
   schema-utils@2.7.0:
     dependencies:
@@ -14486,6 +14532,12 @@ snapshots:
       glob: 7.2.3
       minimatch: 3.1.2
 
+  test-exclude@7.0.1:
+    dependencies:
+      '@istanbuljs/schema': 0.1.3
+      glob: 10.4.5
+      minimatch: 9.0.4
+
   text-table@0.2.0: {}
 
   thunky@1.1.0: {}
@@ -14514,9 +14566,9 @@ snapshots:
     dependencies:
       matchit: 1.1.0
 
-  ts-api-utils@1.3.0(typescript@5.2.2):
+  ts-api-utils@1.3.0(typescript@5.3.3):
     dependencies:
-      typescript: 5.2.2
+      typescript: 5.3.3
 
   ts-expose-internals-conditionally@1.0.0-empty.0: {}
 
@@ -14579,12 +14631,12 @@ snapshots:
     dependencies:
       is-typedarray: 1.0.0
 
-  typedoc-plugin-markdown@3.17.1(typedoc@0.25.13):
+  typedoc-plugin-markdown@3.17.1(typedoc@0.25.13(typescript@5.2.2)):
     dependencies:
       handlebars: 4.7.8
       typedoc: 0.25.13(typescript@5.2.2)
 
-  typedoc-plugin-missing-exports@2.2.0(typedoc@0.25.13):
+  typedoc-plugin-missing-exports@2.2.0(typedoc@0.25.13(typescript@5.2.2)):
     dependencies:
       typedoc: 0.25.13(typescript@5.2.2)
 
@@ -14716,13 +14768,14 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0)(webpack@5.91.0):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.91.0))(webpack@5.91.0):
     dependencies:
-      file-loader: 6.2.0(webpack@5.91.0)
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.91.0
+    optionalDependencies:
+      file-loader: 6.2.0(webpack@5.91.0)
 
   util-deprecate@1.0.2: {}
 
@@ -14871,9 +14924,10 @@ snapshots:
       serve-index: 1.9.1
       sockjs: 0.3.24
       spdy: 4.0.2
-      webpack: 5.91.0
       webpack-dev-middleware: 5.3.4(webpack@5.91.0)
       ws: 8.17.0
+    optionalDependencies:
+      webpack: 5.91.0
     transitivePeerDependencies:
       - bufferutil
       - debug


### PR DESCRIPTION
This PR updates filecoin-api to add pagination to the query interfaces. Currently only the first page of results is returned.

This means in the fileocin pipeline cron jobs we never process more than 1 page of items, even though there are sometimes many more items to process and ample execution time remaining in the lambda.

If only the first page of items is processed it gives a false sense of everything operating ok, when actually things may be backing up. It essentially smothers the issue. If the lambda times out because there are too many items to process then this is a good indication that it needs some attention.

Essentially, the interface changes from:

```ts
interface Queryable<Q, T> {
  query (q: Q): Promise<Result<T[]>>
}
```

To this:

```ts
interface Pageable {
  cursor?: string
  size?: number
}

interface ListSuccess<T> {
  results: T[]
  cursor?: string
}

interface Queryable<Q, T> {
  query (q: Q, options?: Pageable): Promise<Result<ListSuccess<T>>>
}
```

Context: we currently have a _lot_ of `filecoin/accept` receipts we need to issue that are being done in a cron job.