### PR TITLE
refactor: `BlobLike`'s `stream()` matches `Blob`'s

### DIFF
--- a/packages/upload-client/src/car.js
+++ b/packages/upload-client/src/car.js
@@ -98,11 +98,16 @@ export class BlockStream extends ReadableStream {
   }
 }
 
-/* c8 ignore next 20 */
+/* c8 ignore start */
 /**
+ * {@link ReadableStream} is an async iterable in newer environments, but it's
+ * not standard yet. This function normalizes a {@link ReadableStream} to a
+ * definite async iterable.
+ *
  * @template T
- * @param {{ getReader: () => ReadableStreamDefaultReader<T> } | AsyncIterable<T>} stream
- * @returns {AsyncIterable<T>}
+ * @param {ReadableStream<T> | AsyncIterable<T>} stream
+ * @returns {AsyncIterable<T>} An async iterable of the contents of the
+ *                             {@link stream} (possibly {@link stream} itself).
  */
 function toIterable(stream) {
   return Symbol.asyncIterator in stream
@@ -120,3 +125,4 @@ function toIterable(stream) {
         }
       })()
 }
+/* c8 ignore end */

--- a/packages/upload-client/src/types.ts
+++ b/packages/upload-client/src/types.ts
@@ -406,7 +406,7 @@ export interface BlobLike {
   /**
    * Returns a ReadableStream which yields the Blob data.
    */
-  stream: () => ReadableStream
+  stream: Blob['stream']
 }
 
 export interface FileLike extends BlobLike {


### PR DESCRIPTION
Should return a `ReadableStream<Uint8Array>`, not a `ReadableStream<any>`. Get it straight from `Blob` to be sure it matches.

This bit me while trying to work with the API.